### PR TITLE
Added fix for Android ScrollView inexistent pagination

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,26 +6,46 @@ var {
   View,
   Animated,
   ScrollView,
+  Platform,
 } = React;
 
 var DefaultTabBar = require('./DefaultTabBar');
 var deviceWidth = Dimensions.get('window').width;
 
+
 var ScrollableTabView = React.createClass({
   getInitialState() {
-    return { currentPage: 0, pan: new Animated.Value(0) };
+    return {
+      currentPage: 0,
+      pan: new Animated.Value(0)
+    };
   },
 
   componentWillMount() {
     this.state.pan.addListener(({value}) => {
-      var pageNumber = Math.round(Math.max(0, Math.min(value / deviceWidth, this.props.children.length - 1)));
+      var pageNumber = Math.round(
+        Math.max(
+          0,
+          Math.min(value / deviceWidth, this.props.children.length - 1)
+        )
+      );
+
+      // Android hack as ScrollView.pagingEnabled is not supported yet
+      if (
+        Platform.OS === 'android' &&
+        this.state.currentPage != pageNumber &&
+        value % deviceWidth != 0
+      ) {
+        this.refs.scrollView.scrollTo(null, pageNumber * deviceWidth);
+      }
 
       this.setState({
         currentPage: pageNumber
       });
 
       this.props.onChangeTab && this.props.onChangeTab({
-        i: pageNumber, ref: this.props.children[pageNumber]
+        i: pageNumber,
+        ref: this.props.children[pageNumber]
       });
     });
   },
@@ -46,7 +66,8 @@ var ScrollableTabView = React.createClass({
 
   render() {
     var scrollValue = this.state.pan.interpolate({
-      inputRange: [0, deviceWidth * this.props.children.length], outputRange: [0, this.props.children.length]
+      inputRange: [0, deviceWidth * this.props.children.length],
+      outputRange: [0, this.props.children.length]
     });
 
     return (


### PR DESCRIPTION
Hi there,

I found your PR moving scrollable-tab-view to use ScrollView. I was trying this component in Android with some performance issues, however when I tried your fork, performance was normal, probably because ScrollView delegates to native parts and Animation and Gesture handling in Android seem to be missing some optimizations.

Two things called my attention in my project when switching. I have three tabs, each one with a listview of 20 cards:
* First, when using scrollview, my styles were messed up and I had to end up using deviceWidth for my listview cards. Seems that `flex:1` was no longer working.
* Second, scroll now works when putting my finger over a card of my listview, with upstream version that wasn't happening. However, both upstream and your fork, have issues when I touch a card it now takes 2 seconds for the card to get to know it has been tapped (this only happens in a real Android device, not on the simulators, wish I had an iPhone around to try too).

I've add a fix for Android that scrolls to the page you are moving to once you've changed, this way I kind of simulate poor man's pagination, as it this property of ScrollView is only iOS available.

I also changed some coding style, I hope you don't mind.

Cheers,
Miguel